### PR TITLE
Removed leaver mTouhid

### DIFF
--- a/teams.tf
+++ b/teams.tf
@@ -55,7 +55,6 @@ locals {
         "kyphutruong",
         "laurentb4",
         "mitchdawson1982",
-        "mTouhid",
         "smjmoj",
         "staff-infrastructure-moj"
       ]


### PR DESCRIPTION
User accounts which have been removed from the MOJ org will cause the build to fail.